### PR TITLE
Change grid in title from col-md-4 to col-md-12

### DIFF
--- a/resources/views/layouts/main-panel/main.blade.php
+++ b/resources/views/layouts/main-panel/main.blade.php
@@ -117,7 +117,7 @@
     </nav>
   </div>
   <div class="row wrapper border-bottom white-bg page-heading">
-    <div class="col-sm-4">
+    <div class="col-sm-12">
       <h2>@yield('content-title', 'Title')</h2>
       @section('breadcrumbs')
       <ol class="breadcrumb">


### PR DESCRIPTION
Hi @frdteknikelektro. sometimes when title is too long then the view becomes messy. I changed the grid layout title from col-md-4 to col-md-12.